### PR TITLE
Add Cluster creation/list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,5 @@ pom.xml
 .lein-deps-sum
 .lein-failures
 .lein-plugins
+.lein-repl-history
 /.nrepl-port

--- a/readme.md
+++ b/readme.md
@@ -10,9 +10,8 @@
 
 For [Leiningen](https://github.com/technomancy/leiningen):
 
-```clojure
-[bigml/clj-bigml "0.2.0"]
-```
+[![Clojars Project](https://img.shields.io/clojars/v/bigml/clj-bigml.svg)]
+(https://clojars.org/bigml/clj-bigml)
 
 ## Overview
 
@@ -23,7 +22,7 @@ sophisticated machine learning pipelines.
 
 `clj-bigml` aims to make it easier to use BigML.io features from
 Clojure. BigML.io features are always growing and adapting to BigML
-customers' requirements, and `clj-bigml` does currently only supports
+customers' requirements, and `clj-bigml` currently supports only
 a limited subset of those features.
 
 BigML.io takes a white-box approach where it makes sense. This
@@ -291,7 +290,7 @@ course, never trust evaluations on training data.
 A [cluster](https://bigml.com/developers/clusters) is a set of groups
 of instances of a dataset that have been automatically classified
 together according to a distance measure computed using the fields of
-the dataset. Cluster are used in unsupervised learning.
+the dataset.  A clustering is an example of unsupervised learning.
 
 ```clojure
 (def iris-cluster
@@ -302,7 +301,7 @@ the dataset. Cluster are used in unsupervised learning.
 
 A [centroid](https://bigml.com/developers/clusters) represents the
 center of a cluster and is computed using the mean for each numeric
-field and the mode for each categorical field. You can create a
+field and the mode for each categorical field.  You can create a
 centroid for a given cluster and a new data instance to identify the
 cluster's centroid that is closest to the given instance.
 

--- a/readme.md
+++ b/readme.md
@@ -11,28 +11,27 @@
 For [Leiningen](https://github.com/technomancy/leiningen):
 
 ```clojure
-[bigml/clj-bigml "0.1.0"]
+[bigml/clj-bigml "0.2.0"]
 ```
 
 ## Overview
 
-BigML offers a REST-style service for building, sharing, and
-evaluating machine learning models.  Currently the only model variety
-supported is [CART-style decision trees]
-(http://en.wikipedia.org/wiki/Decision_tree_learning) grown in
-an anytime, streaming fashion.  The trees use standard ML practices
-such as information gain (or information gain ratio) for
-classification problems, squared error for regression, and statistical
-pruning options.
+BigML offers a REST-style service, BigML.io, for creating and managing
+BigML resources programmatically. You can use BigML.io for basic
+supervised and unsupervised machine learning tasks and also to create
+sophisticated machine learning pipelines.
 
-The service takes a white-box approach.  While predictions may be made
-through the API, the models can also be downloaded for use locally
-(either as BigML's native JSON format or as
-[PMML](http://www.dmg.org/v4-1/GeneralStructure.html)).
+`clj-bigml` aims to make it easier to use BigML.io features from
+Clojure. BigML.io features are always growing and adapting to BigML
+customers' requirements, and `clj-bigml` does currently only supports
+a limited subset of those features.
 
-The API also supports sampling and randomization options which enable
-ensemble methods such as [random forests]
-(http://en.wikipedia.org/wiki/Random_forest).
+BigML.io takes a white-box approach where it makes sense. This
+includes the possibility of downloading your datasets, models,
+clusters and anomaly detectors and use them locally (either as BigML's
+native JSON format or as
+[PMML](http://www.dmg.org/v4-1/GeneralStructure.html)) in addition to
+being able to use them through BigML API.
 
 Please note, all code samples in this document assume that the
 following namespaces are already required:
@@ -42,6 +41,8 @@ following namespaces are already required:
                      [source :as source]
                      [dataset :as dataset]
                      [model :as model]
+                     [cluster :as cluster]
+                     [centroid :as centroid]
                      [prediction :as prediction]
                      [evaluation :as evaluation]])
 ```
@@ -94,13 +95,13 @@ development mode as parameters when calling client functions:
 
 ## Resources
 
-There are five types of resources in the BigML API:
+The BigML API provides access to a growing number of [ML resources]
+(https://bigml.com/developers/overview#ov_bigml_resources), including
+such resources as
 [sources](https://bigml.com/developers/sources),
 [datasets](https://bigml.com/developers/datasets),
-[models](https://bigml.com/developers/models),
-[predictions](https://bigml.com/developers/predictions), and
-[evaluations](https://bigml.com/developers/evaluations).  For more
-about them, see the [tutorial videos on YouTube]
+[models](https://bigml.com/developers/models), etc.
+For more about them, see the [tutorial videos on YouTube]
 (http://www.youtube.com/playlist?list=PL16FC91153F8C47A7&feature=plcp).
 
 `bigml.api.core` provides a set of functions that act as primitives
@@ -264,7 +265,7 @@ the prediction.
 
 ### Evaluations
 
-Finally, an [evaluation](https://bigml.com/developers/evaluations) of
+An [evaluation](https://bigml.com/developers/evaluations) of
 a model on a dataset may be generated through the API.
 
 We continue the Iris example by evaluating our model on its own
@@ -285,12 +286,42 @@ as a demonstration.
 We have perfect accuracy and a spotless confusion matrix.  But of
 course, never trust evaluations on training data.
 
+### Clusters
+
+A [cluster](https://bigml.com/developers/clusters) is a set of groups
+of instances of a dataset that have been automatically classified
+together according to a distance measure computed using the fields of
+the dataset. Cluster are used in unsupervised learning.
+
+```clojure
+(def iris-cluster
+  (api/get-final (cluster/create iris-dataset)))
+```
+
+### Centroids
+
+A [centroid](https://bigml.com/developers/clusters) represents the
+center of a cluster and is computed using the mean for each numeric
+field and the mode for each categorical field. You can create a
+centroid for a given cluster and a new data instance to identify the
+cluster's centroid that is closest to the given instance.
+
+```clojure
+(def iris-centroid
+    (api/get-final (centroid/create iris-cluster {"000000" 7.6
+                                                  "000001" 3.0
+                                                  "000002" 6.6
+                                                  "000003" 2.1})))
+
+### Clean up resources
+
 If you've been following along in your REPL, you can clean up the
 artifacts generated in these examples like so:
 
 ```clojure
 (mapv api/delete [iris-source iris-dataset iris-model
-                  iris-remote-prediction iris-evaluation])
+                  iris-remote-prediction iris-evaluation
+                  iris-cluster iris-centroid])
 ```
 
 ## More Examples
@@ -311,6 +342,6 @@ in our [Campfire chatroom](https://bigmlinc.campfirenow.com/f20a0).
 
 ## License
 
-Copyright (C) 2012 BigML Inc.
+Copyright (C) 2012-2016 BigML Inc.
 
 Distributed under the Apache License, Version 2.0.

--- a/src/bigml/api/centroid.clj
+++ b/src/bigml/api/centroid.clj
@@ -2,33 +2,40 @@
 ;; Licensed under the Apache License, Version 2.0
 ;; http://www.apache.org/licenses/LICENSE-2.0
 
-(ns bigml.api.cluster
-  "Offers functions specific for BigML clusters.
-     https://bigml.com/developers/clusters"
+(ns bigml.api.centroid
+  "Offers functions specific for BigML centroids.
+     https://bigml.com/developers/centroids."
   (:require (bigml.api [core :as api] [utils :as utils]))
   (:refer-clojure :exclude [list]))
 
 (defn create
-  "Creates a cluster from a dataset. A dataset can be represented through its
+  "Creates a centroid from a cluster. A cluster can be represented through its
   id (e.g., `cluster/123123`), or a map as returned by `get` or `list`.
   
+   The inputs may either be a map (field ids to values), or a
+   sequence of the inputs fields in the order they appeared during
+   training.
+
   Accepts the optional creation parameters described in the BigML API docs:
-     https://bigml.com/developers/clusters#cl_cluster_arguments
+     https://bigml.com/developers/centroids#ct_centroid_arguments
 
   HTTP response information is attached as meta data. Exceptions are thrown
   on failure unless :throw-exceptions is set to false (default is true),
   in which case the HTTP response details are returned as a map on failure."
-  [dataset & params]
-  (utils/create :target :cluster :origin [:dataset dataset] :params params))
+  [cluster inputs & params]
+  (utils/create :target :centroid
+                :origin [:cluster cluster]
+                :params params
+                :inputs inputs))
 
 (defn list
-  "Retrieves a list of clusters. The optional parameters can include
+  "Retrieves a list of centroids. The optional parameters can include
   pagination and filtering options detailed here:
-     https://bigml.com/developers/clusters#cl_listing_clusters
+     https://bigml.com/developers/centroids#ct_listing_centroids
 
   Pagination details are returned as meta data attached to the list, along
   with the HTTP response information. Exceptions are thrown on failure unless
   :throw-exceptions is set to false (default is true), in which case the
   HTTP response details are returned in a map on failure."
   [& params]
-  (apply api/list :cluster params))
+  (apply api/list :centroid params))

--- a/src/bigml/api/cluster.clj
+++ b/src/bigml/api/cluster.clj
@@ -1,0 +1,43 @@
+;; Copyright 2012 BigML
+;; Licensed under the Apache License, Version 2.0
+;; http://www.apache.org/licenses/LICENSE-2.0
+
+(ns bigml.api.cluster
+  "Offers functions specific for BigML clusters.
+     https://bigml.com/developers/clusters"
+  (:require (bigml.api [core :as api]))
+  (:refer-clojure :exclude [list]))
+
+(defn create
+  "Creates a cluster from a dataset. A dataset can be represented through its
+  id (e.g., `cluster/123123`), or a map as returned by `get` or `list`.
+  
+  Accepts the optional creation parameters described in the BigML API docs:
+     https://bigml.com/developers/clusters#cl_cluster_arguments
+
+  HTTP response information is attached as meta data. Exceptions are thrown
+  on failure unless :throw-exceptions is set to false (default is true),
+  in which case the HTTP response details are returned as a map on failure."
+  [dataset & params]
+  (let [params (apply api/query-params params)
+        form-params (assoc (apply dissoc params api/conn-params)
+                      :dataset (api/resource-id dataset))
+        auth-params (select-keys params api/auth-params)]
+    (api/create :cluster
+                (:dev_mode params)
+                {:content-type :json
+                 :throw-exceptions (:throw-exceptions params true)
+                 :form-params (dissoc form-params :throw-exceptions)
+                 :query-params auth-params})))
+
+(defn list
+  "Retrieves a list of clusters. The optional parameters can include
+  pagination and filtering options detailed here:
+     https://bigml.com/developers/clusters#cl_listing_clusters
+
+  Pagination details are returned as meta data attached to the list, along
+  with the HTTP response information. Exceptions are thrown on failure unless
+  :throw-exceptions is set to false (default is true), in which case the
+  HTTP response details are returned in a map on failure."
+  [& params]
+  (apply api/list :cluster params))

--- a/src/bigml/api/cluster.clj
+++ b/src/bigml/api/cluster.clj
@@ -5,7 +5,7 @@
 (ns bigml.api.cluster
   "Offers functions specific for BigML clusters.
      https://bigml.com/developers/clusters"
-  (:require (bigml.api [core :as api]))
+  (:require (bigml.api [core :as api] [utils :as utils]))
   (:refer-clojure :exclude [list]))
 
 (defn create
@@ -19,16 +19,7 @@
   on failure unless :throw-exceptions is set to false (default is true),
   in which case the HTTP response details are returned as a map on failure."
   [dataset & params]
-  (let [params (apply api/query-params params)
-        form-params (assoc (apply dissoc params api/conn-params)
-                      :dataset (api/resource-id dataset))
-        auth-params (select-keys params api/auth-params)]
-    (api/create :cluster
-                (:dev_mode params)
-                {:content-type :json
-                 :throw-exceptions (:throw-exceptions params true)
-                 :form-params (dissoc form-params :throw-exceptions)
-                 :query-params auth-params})))
+  (utils/create :cluster :dataset dataset params))
 
 (defn list
   "Retrieves a list of clusters. The optional parameters can include

--- a/src/bigml/api/dataset.clj
+++ b/src/bigml/api/dataset.clj
@@ -23,7 +23,7 @@
    is true), in which case the HTTP response details are returned as
    a map on failure."
   [source & params]
-  (utils/create :dataset :source source params))
+  (utils/create :target :dataset :origin [:source source] :params params))
 
 (defn clone
   "Clones a given dataset, represented either as a full resource (as
@@ -34,7 +34,7 @@
 
    Error handling is analogous to that of `create`, which see."
   [dataset & params]
-  (utils/create :dataset :origin_dataset dataset params))
+  (utils/create :target :dataset :origin [:origin_dataset dataset] :params params))
 
 (defn list
   "Retrieves a list of datasets. The optional parameters can include

--- a/src/bigml/api/dataset.clj
+++ b/src/bigml/api/dataset.clj
@@ -5,20 +5,8 @@
 (ns bigml.api.dataset
   "Offers functions specific for BigML datasets.
       https://bigml.com/developers/datasets"
-  (:require (bigml.api [core :as api]))
+  (:require (bigml.api [core :as api] [utils :as utils]))
   (:refer-clojure :exclude [list]))
-
-(defn- create* [origin-tag origin params]
-  (let [params (apply api/query-params params)
-        form-params (assoc (apply dissoc params api/conn-params)
-                      origin-tag (api/resource-id origin))
-        auth-params (select-keys params api/auth-params)]
-    (api/create :dataset
-                (:dev_mode params)
-                {:content-type :json
-                 :throw-exceptions (:throw-exceptions params true)
-                 :form-params (dissoc form-params :throw-exceptions)
-                 :query-params auth-params})))
 
 (defn create
   "Creates a dataset given a source. The source may be either a string
@@ -35,7 +23,7 @@
    is true), in which case the HTTP response details are returned as
    a map on failure."
   [source & params]
-  (create* :source source params))
+  (utils/create :dataset :source source params))
 
 (defn clone
   "Clones a given dataset, represented either as a full resource (as
@@ -46,7 +34,7 @@
 
    Error handling is analogous to that of `create`, which see."
   [dataset & params]
-  (create* :origin_dataset dataset params))
+  (utils/create :dataset :origin_dataset dataset params))
 
 (defn list
   "Retrieves a list of datasets. The optional parameters can include

--- a/src/bigml/api/model.clj
+++ b/src/bigml/api/model.clj
@@ -5,7 +5,7 @@
 (ns bigml.api.model
   "Offers functions specific for BigML models.
       https://bigml.com/developers/models"
-  (:require (bigml.api [core :as api]))
+  (:require (bigml.api [core :as api] [utils :as utils]))
   (:refer-clojure :exclude [list]))
 
 (defn create
@@ -23,16 +23,7 @@
    is true), in which case the HTTP response details are returned as
    a map on failure."
   [dataset & params]
-  (let [params (apply api/query-params params)
-        form-params (assoc (apply dissoc params api/conn-params)
-                      :dataset (api/resource-id dataset))
-        auth-params (select-keys params api/auth-params)]
-    (api/create :model
-                (:dev_mode params)
-                {:content-type :json
-                 :throw-exceptions (:throw-exceptions params true)
-                 :form-params (dissoc form-params :throw-exceptions)
-                 :query-params auth-params})))
+  (utils/create :model :dataset dataset params))
 
 (defn list
   "Retrieves a list of models. The optional parameters can include

--- a/src/bigml/api/model.clj
+++ b/src/bigml/api/model.clj
@@ -19,7 +19,7 @@
       https://bigml.com/developers/models#m_create
 
    HTTP response information is attached as meta data. Exceptions are
-   thrown on failure unless :throw-exceptions is set as false (default
+   thrown on failure unless :throw-exceptions is set to false (default
    is true), in which case the HTTP response details are returned as
    a map on failure."
   [dataset & params]
@@ -41,7 +41,7 @@
 
    Pagination details are returned as meta data attached to the list,
    along with the HTTP response information.  Exceptions are thrown on
-   failure unless :throw-exceptions is set as false (default is true),
+   failure unless :throw-exceptions is set to false (default is true),
    in which case the HTTP response details are returned as a map on
    failure."
   [& params]

--- a/src/bigml/api/model.clj
+++ b/src/bigml/api/model.clj
@@ -23,7 +23,7 @@
    is true), in which case the HTTP response details are returned as
    a map on failure."
   [dataset & params]
-  (utils/create :model :dataset dataset params))
+  (utils/create :target :model :origin [:dataset dataset] :params params))
 
 (defn list
   "Retrieves a list of models. The optional parameters can include

--- a/src/bigml/api/prediction.clj
+++ b/src/bigml/api/prediction.clj
@@ -11,7 +11,7 @@
 (defn- convert-inputs [model inputs]
   (let [input-fields (or (:input_fields model)
                          (:input_fields (api/get-final model))
-                         (throw (Exception. "Inaccessable model")))]
+                         (throw (Exception. "Inaccessible model")))]
     (apply hash-map (flatten (map clojure.core/list input-fields inputs)))))
 
 (defn create

--- a/src/bigml/api/source.clj
+++ b/src/bigml/api/source.clj
@@ -10,7 +10,7 @@
   (:require (clojure.java [io :as io])
             (clojure.data [csv :as csv])
             (cheshire [core :as json])
-            (bigml.api [core :as api]))
+            (bigml.api [core :as api] [utils :as utils]))
   (:refer-clojure :exclude [list]))
 
 (defn- url? [url]
@@ -35,16 +35,19 @@
    a map on failure."
   create-type)
 
+;; (defmethod create :url [url & params]
+;;   (let [params (apply api/query-params params)
+;;         form-params (assoc (apply dissoc params api/conn-params) :remote url)
+;;         auth-params (select-keys params api/auth-params)]
+;;     (api/create :source
+;;                 (:dev_mode params)
+;;                 {:content-type :json
+;;                  :throw-exceptions (:throw-exceptions params true)
+;;                  :form-params (dissoc form-params :throw-exceptions)
+;;                  :query-params auth-params})))
+
 (defmethod create :url [url & params]
-  (let [params (apply api/query-params params)
-        form-params (assoc (apply dissoc params api/conn-params) :remote url)
-        auth-params (select-keys params api/auth-params)]
-    (api/create :source
-                (:dev_mode params)
-                {:content-type :json
-                 :throw-exceptions (:throw-exceptions params true)
-                 :form-params (dissoc form-params :throw-exceptions)
-                 :query-params auth-params})))
+  (utils/create :source :remote url params))
 
 (defmethod create :file [file & params]
   (let [file (io/file file)

--- a/src/bigml/api/source.clj
+++ b/src/bigml/api/source.clj
@@ -35,19 +35,8 @@
    a map on failure."
   create-type)
 
-;; (defmethod create :url [url & params]
-;;   (let [params (apply api/query-params params)
-;;         form-params (assoc (apply dissoc params api/conn-params) :remote url)
-;;         auth-params (select-keys params api/auth-params)]
-;;     (api/create :source
-;;                 (:dev_mode params)
-;;                 {:content-type :json
-;;                  :throw-exceptions (:throw-exceptions params true)
-;;                  :form-params (dissoc form-params :throw-exceptions)
-;;                  :query-params auth-params})))
-
 (defmethod create :url [url & params]
-  (utils/create :source :remote url params))
+  (utils/create :target :source :origin [:remote url] :params params))
 
 (defmethod create :file [file & params]
   (let [file (io/file file)

--- a/src/bigml/api/utils.clj
+++ b/src/bigml/api/utils.clj
@@ -1,0 +1,26 @@
+;; Copyright 2016 BigML
+;; Licensed under the Apache License, Version 2.0
+;; http://www.apache.org/licenses/LICENSE-2.0
+
+(ns bigml.api.utils
+  "Offers functions specific for BigML clusters.
+     https://bigml.com/developers/clusters"
+  (:require (bigml.api [core :as api]))
+  (:refer-clojure :exclude [list]))
+
+(defn create
+  "Create a resource from another.
+
+   The origin-tag identifies the type of resource to create, e.g. :source;
+   origin is either a string or a map."
+  [target-tag origin-tag origin params]
+  (let [params (apply api/query-params params)
+        form-params (assoc (apply dissoc params api/conn-params)
+                      origin-tag (api/resource-id origin))
+        auth-params (select-keys params api/auth-params)]
+    (api/create target-tag
+                (:dev_mode params)
+                {:content-type :json
+                 :throw-exceptions (:throw-exceptions params true)
+                 :form-params (dissoc form-params :throw-exceptions)
+                 :query-params auth-params})))

--- a/src/bigml/api/utils.clj
+++ b/src/bigml/api/utils.clj
@@ -5,20 +5,41 @@
 (ns bigml.api.utils
   "Offers functions specific for BigML clusters.
      https://bigml.com/developers/clusters"
-  (:require (bigml.api [core :as api]))
-  (:refer-clojure :exclude [list]))
+  (:require (bigml.api [core :as api])))
+
+(defn normalized-inputs
+  "Converts inputs to their map normal form if provided as list,
+   in which case they are associated to input fields in the order
+   the latter appeared during training."
+  [resource inputs]
+  (let [input-fields (or (:input_fields resource)
+                         (:input_fields (api/get-final resource))
+                         (throw (Exception. "Inaccessible/wrong resource")))]
+    (apply hash-map (flatten (map list input-fields inputs)))))
 
 (defn create
   "Create a resource from another.
 
-   The origin-tag identifies the type of resource to create, e.g. :source;
-   origin is either a string or a map."
-  [target-tag origin-tag origin params]
-  (let [params (apply api/query-params params)
+   The `target` parameter identifies the type of resource to create,
+   `origin` is either a tuple containing the type of the resource used
+   to create `target` and its id string, or a map containing the resource
+   as returned by `get` or `list`. E.g.:
+
+     (create :target :model :origin [:dataset '123123']
+     (create :target :prediction :origin [:model '123123'] :inputs {...}"
+  [& {:keys [target origin params inputs]}]
+  (let [origin-id (api/resource-id (peek origin))
+        inputs (if (and inputs (not (map? inputs)) (coll? inputs))
+                 (normalized-inputs origin-id inputs)
+                 inputs)
+        params (apply api/query-params params)
         form-params (assoc (apply dissoc params api/conn-params)
-                      origin-tag (api/resource-id origin))
+                      (first origin) origin-id)
+        form-params (if inputs 
+                      (assoc form-params :input_data inputs)
+                      form-params)
         auth-params (select-keys params api/auth-params)]
-    (api/create target-tag
+    (api/create target
                 (:dev_mode params)
                 {:content-type :json
                  :throw-exceptions (:throw-exceptions params true)

--- a/test/bigml/test/api/integration.clj
+++ b/test/bigml/test/api/integration.clj
@@ -7,6 +7,7 @@
                        [source :as source]
                        [dataset :as dataset]
                        [model :as model]
+                       [cluster :as cluster]
                        [prediction :as prediction]
                        [evaluation :as evaluation]))
   (:use clojure.test))
@@ -19,14 +20,16 @@
         model (api/get-final (model/create dataset))
         pred (prediction/create model (first data))
         eval (api/get-final (evaluation/create model dataset))
-        predictor (prediction/predictor model)]
-    (doall (pmap api/delete [source dataset model pred eval]))
+        predictor (prediction/predictor model)
+        cluster (api/get-final (cluster/create dataset))]
+    (doall (pmap api/delete [source dataset model pred eval cluster]))
     (is (== 10 (predictor [8 2]) (predictor [5 5])))
     (is source)
     (is dataset)
     (is model)
     (is pred)
-    (is eval)))
+    (is eval)
+    (is cluster)))
 
 (deftest integration
   (test-with-generated-data))

--- a/test/bigml/test/api/integration.clj
+++ b/test/bigml/test/api/integration.clj
@@ -8,6 +8,7 @@
                        [dataset :as dataset]
                        [model :as model]
                        [cluster :as cluster]
+                       [centroid :as centroid]
                        [prediction :as prediction]
                        [evaluation :as evaluation]))
   (:use clojure.test))
@@ -21,15 +22,18 @@
         pred (prediction/create model (first data))
         eval (api/get-final (evaluation/create model dataset))
         predictor (prediction/predictor model)
-        cluster (api/get-final (cluster/create dataset))]
-    (doall (pmap api/delete [source dataset model pred eval cluster]))
+        cluster (api/get-final (cluster/create dataset))
+        centroid (centroid/create cluster (first data))]
+    (doall (pmap api/delete
+                 [source dataset model pred eval cluster centroid]))
     (is (== 10 (predictor [8 2]) (predictor [5 5])))
     (is source)
     (is dataset)
     (is model)
     (is pred)
     (is eval)
-    (is cluster)))
+    (is cluster)
+    (is centroid)))
 
 (deftest integration
   (test-with-generated-data))

--- a/test/bigml/test/api/source.clj
+++ b/test/bigml/test/api/source.clj
@@ -8,11 +8,13 @@
   (:use clojure.test))
 
 (defn- create-and-test [artifact & params]
-  (let [initial (api/get-final (apply source/create artifact params))
+  (let [{:keys [username api_key dev_mode] :as sticky-pars} params
+        sticky-pars (flatten (seq sticky-pars))
+        initial (apply api/get-final (apply source/create artifact params) sticky-pars)
         source-name (str "test-source" (rand-int 1000))
-        updated (api/update initial {:name source-name})
-        retrieved (api/get updated)
-        deleted (api/delete retrieved)]
+        updated (apply api/update initial {:name source-name} sticky-pars)
+        retrieved (apply api/get updated sticky-pars)
+        deleted (apply api/delete retrieved sticky-pars)]
     (is (and initial updated retrieved))
     (is (true? deleted))
     (is (thrown? Exception (api/get initial)))
@@ -20,7 +22,7 @@
 
 (deftest sources
   (testing "Source creation from file"
-    (create-and-test "test/data/iris.csv.gz"))
+    (create-and-test "test/data/iris.csv.gz" :dev_mode true))
   (testing "Source creation from url"
     (create-and-test "https://static.bigml.com/csv/iris.csv"))
   (testing "Source creation from collection"

--- a/test/bigml/test/api/source.clj
+++ b/test/bigml/test/api/source.clj
@@ -7,10 +7,13 @@
                        [source :as source]))
   (:use clojure.test))
 
-(defn- create-and-test [artifact & params]
-  (let [{:keys [username api_key dev_mode] :as sticky-pars} params
-        sticky-pars (flatten (seq sticky-pars))
-        initial (apply api/get-final (apply source/create artifact params) sticky-pars)
+(defn- create-and-test [artifact & {:as params}]
+  (let [sticky-pars (flatten (seq (select-keys 
+                                   params
+                                   [:username :api_key :dev_mode])))
+        params (flatten (seq params))
+        initial (apply api/get-final
+                       (apply source/create artifact params) sticky-pars)
         source-name (str "test-source" (rand-int 1000))
         updated (apply api/update initial {:name source-name} sticky-pars)
         retrieved (apply api/get updated sticky-pars)


### PR DESCRIPTION
This PR adds Cluster creation and listing, along the lines of already existing resources.

To reduce the amount of replicated code, it also introduces a new, generic `create` function and refactors existing resources' implementation to use it where appropriate.