### PR TITLE
Add support for specifying inputs using field names instead of field IDs

### DIFF
--- a/src/bigml/api/evaluation.clj
+++ b/src/bigml/api/evaluation.clj
@@ -5,7 +5,8 @@
 (ns bigml.api.evaluation
   "Offers functions specific for BigML evaluations.
       https://bigml.com/developers/evaluations"
-  (:require (bigml.api [core :as api]))
+  (:require (bigml.api [core :as api]
+                       [utils :as utils]))
   (:refer-clojure :exclude [list]))
 
 (defn create
@@ -25,7 +26,7 @@
    a map on failure."
   [model dataset & params]
   (let [params (apply api/query-params params)
-        form-params (assoc (apply dissoc params api/conn-params)
+        form-params (assoc (utils/get-form-params-in params)
                       :model (api/resource-id model)
                       :dataset (api/resource-id dataset))
         auth-params (select-keys params api/auth-params)]

--- a/src/bigml/api/prediction.clj
+++ b/src/bigml/api/prediction.clj
@@ -28,9 +28,9 @@
    a map on failure."
   [model inputs & params]
   (utils/create :target :prediction
-                :origin [:model model]
-                :params params
-                :inputs inputs))
+                 :origin [:model model]
+                 :params params
+                 :inputs inputs))
 
 (defn list
   "Retrieves a list of predictions. The optional parameters can include

--- a/src/bigml/api/prediction.clj
+++ b/src/bigml/api/prediction.clj
@@ -92,9 +92,9 @@
         root-fn (or (node-fn (get-root model))
                     (throw (Exception. "Invalid or unsupported model")))
         obj-field (keyword (first (:objective_fields model)))]
-    (fn [inputs & {:keys [details]}]
+    (fn [inputs & {:keys [details by-name]}]
       (let [inputs (if (and (not (map? inputs)) (coll? inputs))
-                     (utils/normalized-inputs model inputs)
+                     (utils/normalized-inputs model inputs by-name)
                      inputs)
             result (root-fn inputs)]
         (if details

--- a/src/bigml/api/prediction.clj
+++ b/src/bigml/api/prediction.clj
@@ -28,9 +28,9 @@
    a map on failure."
   [model inputs & params]
   (utils/create :target :prediction
-                 :origin [:model model]
-                 :params params
-                 :inputs inputs))
+                :origin [:model model]
+                :params params
+                :inputs inputs))
 
 (defn list
   "Retrieves a list of predictions. The optional parameters can include

--- a/src/bigml/api/source.clj
+++ b/src/bigml/api/source.clj
@@ -15,9 +15,8 @@
   (:refer-clojure :exclude [list]))
 
 (defn- url? [url]
-  (or
-   (.isValid (UrlValidator.) url)
-   (re-find (re-pattern "^s3://") url)))
+  (or (.isValid (UrlValidator.) url)
+      (re-find (re-pattern "^s3://") url)))
 
 (defn- create-type [v & _]
   (cond (and (coll? v) (coll? (first v))) :collection
@@ -55,7 +54,7 @@
     (api/create :source
                 (:dev_mode params)
                 {:multipart multipart
-                  :query-params auth-params})))
+                 :query-params auth-params})))
 
 (defmethod create :collection [coll & params]
   (with-open [writer (StringWriter.)]

--- a/src/bigml/api/source.clj
+++ b/src/bigml/api/source.clj
@@ -42,20 +42,19 @@
   (utils/create :target :source :origin [:remote url] :params params))
 
 (defmethod create :file [file & params]
-  (let [_ (println "source/create: " params)
-         file (io/file file)
-         params (apply api/query-params params)
-         form-params (utils/get-form-params-in params)
-         auth-params (select-keys params api/auth-params)
-         multipart (map (fn [[k v]] {:name (name k)
-                                     :content (if (map? v)
-                                                (json/generate-string v)
-                                                (str v))})
-                        form-params)
-         multipart (conj multipart {:name "file" :content file})]
-     (api/create :source
-                 (:dev_mode params)
-                 {:multipart multipart
+  (let [file (io/file file)
+        params (apply api/query-params params)
+        form-params (utils/get-form-params-in params)
+        auth-params (select-keys params api/auth-params)
+        multipart (map (fn [[k v]] {:name (name k)
+                                    :content (if (map? v)
+                                               (json/generate-string v)
+                                               (str v))})
+                       form-params)
+        multipart (conj multipart {:name "file" :content file})]
+    (api/create :source
+                (:dev_mode params)
+                {:multipart multipart
                   :query-params auth-params})))
 
 (defmethod create :collection [coll & params]

--- a/src/bigml/api/source.clj
+++ b/src/bigml/api/source.clj
@@ -14,7 +14,9 @@
   (:refer-clojure :exclude [list]))
 
 (defn- url? [url]
-  (.isValid (UrlValidator.) url))
+  (or
+   (.isValid (UrlValidator.) url)
+   (re-find (re-pattern "^s3://") url)))
 
 (defn- create-type [v & _]
   (cond (and (coll? v) (coll? (first v))) :collection

--- a/src/bigml/api/utils.clj
+++ b/src/bigml/api/utils.clj
@@ -5,20 +5,45 @@
 (ns bigml.api.utils
   "Offers functions specific for BigML clusters.
      https://bigml.com/developers/clusters"
+  (:require [clojure.set :as set])
   (:require (bigml.api [core :as api])))
+
+(defn- if-contains 
+  "Returns the passed map m if it contains the given key k, otherwise nil"
+  [m k] (and (k m) m))
+
+(defn normalized-resource
+  "Makes sure the passed resource contains enough information for input
+   normalization (i.e., :input_fields and additionally :restype/field
+   when by-name is true. If it does not, then the resoure is fetched."
+  [resource by-name]
+  (or (and (if-contains resource :input_fields)
+            (or (if-contains resource :fields)
+                (and (not by-name) resource)))
+       (api/get-final resource)))
 
 (defn normalized-inputs
   "Converts inputs to their map normal form if provided as list,
    in which case they are associated to input fields in the order
    the latter appeared during training."
-  [resource inputs]
-  (let [input-fields (or (:input_fields resource)
-                         (:input_fields (api/get-final resource))
-                         (throw (Exception. "Inaccessible/wrong resource")))]
-    (apply hash-map (flatten (map list input-fields inputs)))))
+  [resource inputs by-name]
+  (let [_ (println "INPUTS: " inputs)
+        resource ((or (normalized-resource resource)
+                      (throw (Exception. "Inaccessible/wrong resource"))))
+        input-fields (:input_fields resource)
+
+        _ (println "IN-FILEDS" (clojure.string/split (:resource (api/get-final resource)resource) #"/"))]
+    (if (and (map? inputs) by-name)
+      (set/rename-keys inputs (reduce #(assoc %1 (:name (second %2)) (first %2)) {} (seq (:fields (api/get-final resource)))))
+      (apply hash-map (flatten (map list input-fields inputs))))))
+
+(defn get-form-params-in
+  "Filters parameters that are meant to be sent as HTTP form fields."
+  [params]
+  (apply dissoc params (conj api/conn-params :dev_mode :by-field-name)))
 
 (defn create
-  "Create a resource from another.
+  "Creates a resource from another.
 
    The `target` parameter identifies the type of resource to create,
    `origin` is either a tuple containing the type of the resource used
@@ -29,11 +54,14 @@
      (create :target :prediction :origin [:model '123123'] :inputs {...}"
   [& {:keys [target origin params inputs]}]
   (let [origin-id (api/resource-id (peek origin))
-        inputs (if (and inputs (not (map? inputs)) (coll? inputs))
-                 (normalized-inputs origin-id inputs)
+        by-name (if (coll? params) (:by-field-name (apply hash-map params)) false)
+        _ (println "BYNAME: " by-name)
+        inputs (if (and inputs (or (not (map? inputs)) by-name) (coll? inputs))
+                 (normalized-inputs origin-id inputs by-name)
                  inputs)
+        _ (println "NORMALIZED: " inputs)
         params (apply api/query-params params)
-        form-params (assoc (apply dissoc params api/conn-params)
+        form-params (assoc (get-form-params-in params)
                       (first origin) origin-id)
         form-params (if inputs
                       (assoc form-params :input_data inputs)

--- a/src/bigml/api/utils.clj
+++ b/src/bigml/api/utils.clj
@@ -3,22 +3,21 @@
 ;; http://www.apache.org/licenses/LICENSE-2.0
 
 (ns bigml.api.utils
-  "Offers functions specific for BigML clusters.
-     https://bigml.com/developers/clusters"
-  (:require [clojure.set :as set])
-  (:require (bigml.api [core :as api])))
+  "Offers generally useful functions for BigML resources."
+  (:require [clojure.set :as set]
+            (bigml.api [core :as api])))
 
 (defn resource-type
   "Returns the resource type of the specified resource.
-   The resource can be specified through:
-    - its full UUID, e.g., 'model/12234567890';
-    - a minimal map-representation, e.g., { :resource '...' };
-    - a full JSON representation."
+  The resource can be specified through:
+  - its full UUID, e.g., 'model/12234567890';
+  - a minimal map-representation, e.g., { :resource '...' };
+  - a full JSON representation."
   [resource]
   (let [resource (or (:resource resource) (str resource))]
     (first (clojure.string/split resource #"/"))))
 
-(defn- if-contains
+(defn- get-keypath
   "Returns the passed map m if it contains the given keypath ks,
   otherwise nil. A keypath is a sequence of keys for recursive lookup."
   [m ks]
@@ -26,36 +25,37 @@
 
 (defn normalized-resource
   "Makes sure the passed resource contains enough information for input
-   normalization (i.e., :input_fields and additionally :restype/field
-   when by-name is true. If it does not, then the resoure is fetched."
+  normalization (i.e., :input_fields and additionally :restype/field
+  when by-name is true. If it does not, then the resoure is fetched."
   [resource by-name]
-  (let [ res-type (resource-type resource)]
-   (or (and (if-contains resource [:input_fields])
-            (or (if-contains resource [(keyword res-type) :fields])
-                (and (not by-name) resource)))
-       (api/get-final resource))))
+  (let [res-type (resource-type resource)]
+    (or (and (map? resource)
+             (contains? resource :input_fields)
+             (or (get-keypath resource [(keyword res-type) :fields])
+                 (and (not by-name) resource)))
+        (api/get-final resource))))
 
 (defn- field-name-mapping
   "Returns a map that associates the passed resource's field names to
   the respective field IDs. E.g.:
-      {'petal width' '000001' 'sepal length '000002' }"
+  {'petal width' '000001' 'sepal length '000002' }"
   [resource]
   (let [res-type (resource-type resource)]
-    (reduce #(assoc %1 (:name (second %2)) (first %2))
+    (reduce (fn [m [k v]] (assoc m (:name v) k))
             {}
-            (seq (:fields ((keyword res-type) resource))))))
+            (:fields ((keyword res-type) resource)))))
 
 (defn normalized-inputs
   "Converts inputs to their map normal form if provided as list,
-   in which case they are associated to input fields in the order
-   the latter appeared during training."
+  in which case they are associated to input fields in the order
+  the latter appeared during training."
   [resource inputs by-name]
   (let [resource (or (normalized-resource resource by-name)
                       (throw (Exception. "Inaccessible/wrong resource")))
         input-fields (:input_fields resource)]
     (if (and (map? inputs) by-name)
       (set/rename-keys inputs (field-name-mapping resource))
-      (apply hash-map (flatten (map list input-fields inputs))))))
+      (zipmap input-fields inputs))))
 
 (defn get-form-params-in
   "Filters parameters that are meant to be sent as HTTP form fields."

--- a/test/bigml/test/api/others.clj
+++ b/test/bigml/test/api/others.clj
@@ -1,0 +1,38 @@
+;; Copyright 2016 BigML
+;; Licensed under the Apache License, Version 2.0
+;; http://www.apache.org/licenses/LICENSE-2.0
+
+(ns bigml.test.api.others
+  "Contains unit tests for various functions."
+  (:require (bigml.api [utils :as utils]))
+  (:require (bigml.api [core :as api]))
+  (:use clojure.test))
+
+(defn normalized-resource-test 
+  "Tests for utils/normalized-resource. Each test sample shall contain:
+    - the resource to normalize (a map);
+    - the by-name flag (true of false);
+    - the expected outcome (true or false)."
+  [resource by-name]
+  (try
+    (utils/normalized-resource resource
+                               by-name)
+    (catch Exception e (if (.contains (.getMessage e) "404")
+                         "exception"
+                         (throw e)))))
+
+(deftest normalized-resource-test-1
+  (let [r {:resource "sample/uuid"}]
+    (is (= (normalized-resource-test r false) "exception"))))
+
+(deftest normalized-resource-test-2
+  (let [r {:resource "sample/uuid" :input_fields ""}]
+    (is (= (normalized-resource-test r false) r))))
+
+(deftest normalized-resource-test-3
+  (let [r {:resource "sample/uuid"  :input_fields ""}]
+    (is (= (normalized-resource-test r true) "exception"))))
+
+(deftest normalized-resource-test-4
+  (let [r {:resource "sample/uuid"  :input_fields "" :fields ""}]
+    (is (= (normalized-resource-test r true) r))))

--- a/test/bigml/test/api/others.clj
+++ b/test/bigml/test/api/others.clj
@@ -36,3 +36,57 @@
 (deftest normalized-resource-test-4
   (let [r {:resource "sample/uuid"  :input_fields "" :fields ""}]
     (is (= (normalized-resource-test r true) r))))
+
+(deftest field-name-mapping-test-1
+  (let [r {:resource "model/uuid"
+           :model {:fields
+                   { "01" { :name "a" }
+                     "02" { :name "b" }}}}]
+    (is (.equals (#'bigml.api.utils/field-name-mapping r)
+                  {"a" "01" "b" "02"}))))
+
+(deftest field-name-mapping-test-2
+  (let [r {:resource "ensemble/uuid"
+           :ensemble {:fields
+                   { "01" { :name "a" }
+                     "02" { :name "b" }}}}]
+    (is (.equals (#'bigml.api.utils/field-name-mapping r)
+                  {"a" "01" "b" "02"}))))
+
+(deftest field-name-mapping-test-3
+  (let [r {:resource "model/uuid"}]
+    (is (.equals (#'bigml.api.utils/field-name-mapping r) {}))))
+
+(deftest field-name-mapping-test-4
+  (let [r {}]
+    (is (.equals (#'bigml.api.utils/field-name-mapping r) {}))))
+
+(deftest resource-type-test-1
+  (is (= (utils/resource-type "model/12345") "model")))
+
+(deftest resource-type-test-2
+  (is (= (utils/resource-type {:resource "model/12345"}) "model")))
+
+(deftest resource-type-test-3
+  (is (= (utils/resource-type {}) "{}")))
+
+(deftest resource-type-test-4
+  (is (= (utils/resource-type "") "")))
+
+(deftest if-contains-test-1
+  (let [r {:0 "0" :1 { :2 "2" :3 "3"}}]
+      (is (= (#'utils/if-contains r [:0]) r))))
+
+(deftest if-contains-test-2
+  (let [r {:0 "0" :1 { :2 "2" :3 { :4 "4" }}}]
+      (is (= (#'utils/if-contains r [:1 :3 :4]) r))))
+
+(deftest if-contains-test-3
+  (let [r {:0 "0" :1 { :2 "2" :3 "3"}}]
+      (is (= (#'utils/if-contains r [:5]) nil))))
+
+(deftest if-contains-test-4
+  (is (= (#'utils/if-contains {} [:0]) nil)))
+
+(deftest if-contains-test-5
+  (is (= (#'utils/if-contains "" [:5]) nil)))

--- a/test/bigml/test/api/others.clj
+++ b/test/bigml/test/api/others.clj
@@ -4,38 +4,36 @@
 
 (ns bigml.test.api.others
   "Contains unit tests for various functions."
-  (:require (bigml.api [utils :as utils]))
-  (:require (bigml.api [core :as api]))
+  (:require (bigml.api [utils :as utils]
+                       [core :as api]))
   (:use clojure.test))
-
-(defn normalized-resource-test 
-  "Tests for utils/normalized-resource. Each test sample shall contain:
-    - the resource to normalize (a map);
-    - the by-name flag (true of false);
-    - the expected outcome (true or false)."
-  [resource by-name]
-  (try
-    (utils/normalized-resource resource
-                               by-name)
-    (catch Exception e (if (.contains (.getMessage e) "404")
-                         "exception"
-                         (throw e)))))
 
 (deftest normalized-resource-test-1
   (let [r {:resource "sample/uuid"}]
-    (is (= (normalized-resource-test r false) "exception"))))
+    (is (thrown-with-msg? Exception #"404"
+                          (utils/normalized-resource r false)))))
 
 (deftest normalized-resource-test-2
   (let [r {:resource "sample/uuid" :input_fields ""}]
-    (is (= (normalized-resource-test r false) r))))
+    (is (= (utils/normalized-resource r false) r))))
 
 (deftest normalized-resource-test-3
   (let [r {:resource "sample/uuid"  :input_fields ""}]
-    (is (= (normalized-resource-test r true) "exception"))))
+    (is (thrown-with-msg? Exception #"404"
+                          (utils/normalized-resource r true)))))
 
 (deftest normalized-resource-test-4
-  (let [r {:resource "sample/uuid"  :input_fields "" :fields ""}]
-    (is (= (normalized-resource-test r true) r))))
+  (let [r {:resource "sample/uuid"  :input_fields "" :sample {:fields ""}}]
+    (is (= (utils/normalized-resource r true) r))))
+
+(deftest normalized-resource-test-5
+  (let [r {:resource "sample/uuid"  :input_fields "" :sample {:fields ""}}]
+    (is (= (utils/normalized-resource r false) r))))
+
+(deftest normalized-resource-test-6
+  (let [r {:resource "sample/uuid"  :input_fields "" :samplee {:fields ""}}]
+    (is (thrown-with-msg? Exception #"404"
+                          (utils/normalized-resource r true) r))))
 
 (deftest field-name-mapping-test-1
   (let [r {:resource "model/uuid"
@@ -73,20 +71,20 @@
 (deftest resource-type-test-4
   (is (= (utils/resource-type "") "")))
 
-(deftest if-contains-test-1
+(deftest get-keypath-test-1
   (let [r {:0 "0" :1 { :2 "2" :3 "3"}}]
-      (is (= (#'utils/if-contains r [:0]) r))))
+      (is (= (#'utils/get-keypath r [:0]) r))))
 
-(deftest if-contains-test-2
+(deftest get-keypath-test-2
   (let [r {:0 "0" :1 { :2 "2" :3 { :4 "4" }}}]
-      (is (= (#'utils/if-contains r [:1 :3 :4]) r))))
+      (is (= (#'utils/get-keypath r [:1 :3 :4]) r))))
 
-(deftest if-contains-test-3
+(deftest get-keypath-test-3
   (let [r {:0 "0" :1 { :2 "2" :3 "3"}}]
-      (is (= (#'utils/if-contains r [:5]) nil))))
+      (is (= (#'utils/get-keypath r [:5]) nil))))
 
-(deftest if-contains-test-4
-  (is (= (#'utils/if-contains {} [:0]) nil)))
+(deftest get-keypath-test-4
+  (is (= (#'utils/get-keypath {} [:0]) nil)))
 
-(deftest if-contains-test-5
-  (is (= (#'utils/if-contains "" [:5]) nil)))
+(deftest get-keypath-test-5
+  (is (= (#'utils/get-keypath "" [:5]) nil)))

--- a/test/bigml/test/api/t01.clj
+++ b/test/bigml/test/api/t01.clj
@@ -29,16 +29,18 @@
                   [:source :dataset :model :prediction] td)]
         (is (= (last td) (first (vals (:prediction pred)))))))))
 
-;; shall we add support for S3 also? e.g., s3://bigml-public/csv/iris.csv
 (deftest ts02
   "Successfully creating a prediction from remote source"
   (api/with-dev-mode false
-    (doseq [td [["https://static.bigml.com/csv/iris.csv"
-                 {:prediction [1.44 0.54 2.2]}
-                 "Iris-setosa"]]]
+    (doseq [test-data [["https://static.bigml.com/csv/iris.csv"
+                        {:prediction [1.44 0.54 2.2]}
+                        "Iris-setosa"]
+                       ["s3://bigml-public/csv/iris.csv"
+                        {:prediction [1.44 0.54 2.2]}
+                        "Iris-setosa"]]]
       (let [pred (test/create-get-cleanup
-                  [:source :dataset :model :prediction] td)]
-        (is (= (last td) (first (vals (:prediction pred)))))))))
+                  [:source :dataset :model :prediction] test-data)]
+        (is (= (last test-data) (first (vals (:prediction pred)))))))))
 
 (deftest ts04
   "Successfully creating a prediction from inline data source"

--- a/test/bigml/test/api/t01.clj
+++ b/test/bigml/test/api/t01.clj
@@ -33,12 +33,21 @@
                                       :options
                                       { :by-field-name false }}}
                         "Iris-setosa"]
+                       ["test/data/iris.csv.gz"
+                        {:source {"category" "1"}
+                         :prediction {:input_data
+                                      { "petal length" 2.4
+                                        "sepal width" 3.9 }
+                                      :options
+                                      { :by-field-name true }}}
+                        "Iris-setosa"]
                        ["test/data/iris-sp-chars.csv"
                         {:prediction {:input_data [1.44 0.54 2.2]}}
                         "Iris-setosa"]
                        ["test/data/iris-sp-chars.csv"
                         {:prediction {:input_data
-                                      {"sépal.length" 0.25 "pétal&width" 0.5}
+                                      {"sépal.length" 0.25
+                                       "pétal&width" 0.5}
                                       :options
                                       { :by-field-name true }}}
                         "Iris-setosa"]]]
@@ -50,10 +59,10 @@
   "Successfully creating a prediction from remote source"
   (api/with-dev-mode false
     (doseq [test-data [["https://static.bigml.com/csv/iris.csv"
-                        {:prediction [1.44 0.54 2.2]}
+                        {:prediction {:input_data [1.44 0.54 2.2]}}
                         "Iris-setosa"]
                        ["s3://bigml-public/csv/iris.csv"
-                        {:prediction [1.44 0.54 2.2]}
+                        {:prediction {:input_data [1.44 0.54 2.2]}}
                         "Iris-setosa"]]]
       (create-and-test [:source :dataset :model :prediction]
                        test-data
@@ -62,7 +71,7 @@
 (deftest ts04
   "Successfully creating a prediction from inline data source"
   (doseq [test-data [[(take-csv "test/data/iris-sp-chars.csv")
-                 {:prediction [1.44 0.54 2.2]}
+                 {:prediction {:input_data [1.44 0.54 2.2]}}
                  "Iris-setosa"]]]
     (create-and-test [:source :dataset :model :prediction]
                      test-data
@@ -72,7 +81,7 @@
   "Successfully creating a centroid and the associated dataset"
   (api/with-dev-mode true
     (doseq [test-data [["test/data/diabetes.csv"
-                 {:centroid [0 118 84 47 230 45.8 0.551 31 "true"]}
+                 {:centroid {:input_data [0 118 84 47 230 45.8 0.551 31 "true"]}}
                  "Cluster 0"]]]
       (create-and-test [:source :dataset :cluster :centroid]
                        test-data

--- a/test/bigml/test/api/t01.clj
+++ b/test/bigml/test/api/t01.clj
@@ -16,14 +16,6 @@
   (with-open [file (io/reader fname)]
     (doall (csv/read-csv (slurp file)))))
 
-(defn create-get-cleanup
-  "This function takes a sequence of resources to create (e.g.,
-  [:source :dataset :model] and a prediction to check, which is
-  an array whose first item is the inputs to use for the prediction
-  and the second the expected outcome."
-  [res-type [uuid params]]
-  (test/create-get-cleanup res-type uuid params))
-
 (deftest ts01
   "Successfully creating predictions from sources of various kind"
   (api/with-dev-mode true
@@ -33,7 +25,7 @@
                 ["test/data/iris-sp-chars.csv"
                  {:prediction [1.44 0.54 2.2]}
                  "Iris-setosa"]]]
-      (let [pred (create-get-cleanup
+      (let [pred (test/create-get-cleanup
                   [:source :dataset :model :prediction] td)]
         (is (= (last td) (first (vals (:prediction pred)))))))))
 
@@ -44,7 +36,7 @@
     (doseq [td [["https://static.bigml.com/csv/iris.csv"
                  {:prediction [1.44 0.54 2.2]}
                  "Iris-setosa"]]]
-      (let [pred (create-get-cleanup
+      (let [pred (test/create-get-cleanup
                   [:source :dataset :model :prediction] td)]
         (is (= (last td) (first (vals (:prediction pred)))))))))
 
@@ -53,7 +45,7 @@
   (doseq [td [[(take-csv "test/data/iris-sp-chars.csv")
                  {:prediction [1.44 0.54 2.2]}
                  "Iris-setosa"]]]
-      (let [pred (create-get-cleanup
+      (let [pred (test/create-get-cleanup
                   [:source :dataset :model :prediction] td)]
         (is (= (last td) (first (vals (:prediction pred))))))))
 
@@ -63,6 +55,6 @@
     (doseq [td [["test/data/diabetes.csv"
                  {:centroid [0 118 84 47 230 45.8 0.551 31 "true"]}
                  "Cluster 0"]]]
-      (let [centroid (create-get-cleanup
+      (let [centroid (test/create-get-cleanup
                       [:source :dataset :cluster :centroid] td)]
         (is (= (last td) (:centroid_name centroid)))))))

--- a/test/bigml/test/api/t01.clj
+++ b/test/bigml/test/api/t01.clj
@@ -27,13 +27,13 @@
   "Successfully creating predictions from sources of various kind"
   (api/with-dev-mode true
     (doseq [test-data [["test/data/iris.csv.gz"
-                 {:prediction [1.44 0.54 2.2]}
+                 {:prediction { "000001" 0.25 "000003" 0.5}}
                  "Iris-setosa"]
                 ["test/data/iris-sp-chars.csv"
                  {:prediction [1.44 0.54 2.2]}
                  "Iris-setosa"]
                 ["test/data/iris-sp-chars.csv"
-                 {:prediction { "000003" 0.5}}
+                 {:prediction { "000001" 0.25 "000003" 0.5}}
                  "Iris-setosa"]]]
       (create-and-test [:source :dataset :model :prediction]
                        test-data

--- a/test/bigml/test/api/t01.clj
+++ b/test/bigml/test/api/t01.clj
@@ -27,14 +27,21 @@
   "Successfully creating predictions from sources of various kind"
   (api/with-dev-mode true
     (doseq [test-data [["test/data/iris.csv.gz"
-                 {:prediction { "000001" 0.25 "000003" 0.5}}
-                 "Iris-setosa"]
-                ["test/data/iris-sp-chars.csv"
-                 {:prediction [1.44 0.54 2.2]}
-                 "Iris-setosa"]
-                ["test/data/iris-sp-chars.csv"
-                 {:prediction { "000001" 0.25 "000003" 0.5}}
-                 "Iris-setosa"]]]
+                        {:source {"category" "1"}
+                         :prediction {:input_data
+                                      { "000001" 0.25 "000003" 0.5}
+                                      :options
+                                      { :by-field-name true }}}
+                        "Iris-setosa"]
+                       ["test/data/iris-sp-chars.csv"
+                        {:prediction {:input_data [1.44 0.54 2.2]}}
+                        "Iris-setosa"]
+                       ["test/data/iris-sp-chars.csv"
+                        {:prediction {:input_data
+                                      { "000001" 0.25 "000003" 0.5}
+                                      :options
+                                      { :by-field-name true }}}
+                        "Iris-setosa"]]]
       (create-and-test [:source :dataset :model :prediction]
                        test-data
                        predicted-value))))

--- a/test/bigml/test/api/t01.clj
+++ b/test/bigml/test/api/t01.clj
@@ -17,7 +17,7 @@
     (doall (csv/read-csv (slurp file)))))
 
 (defn create-get-cleanup
-  "This function takes a sequence of resource to create (e.g.,
+  "This function takes a sequence of resources to create (e.g.,
   [:source :dataset :model] and a prediction to check, which is
   an array whose first item is the inputs to use for the prediction
   and the second the expected outcome."

--- a/test/bigml/test/api/t01.clj
+++ b/test/bigml/test/api/t01.clj
@@ -31,14 +31,14 @@
                          :prediction {:input_data
                                       { "000001" 0.25 "000003" 0.5}
                                       :options
-                                      { :by-field-name true }}}
+                                      { :by-field-name false }}}
                         "Iris-setosa"]
                        ["test/data/iris-sp-chars.csv"
                         {:prediction {:input_data [1.44 0.54 2.2]}}
                         "Iris-setosa"]
                        ["test/data/iris-sp-chars.csv"
                         {:prediction {:input_data
-                                      { "000001" 0.25 "000003" 0.5}
+                                      {"sépal.length" 0.25 "pétal&width" 0.5}
                                       :options
                                       { :by-field-name true }}}
                         "Iris-setosa"]]]

--- a/test/bigml/test/api/t02.clj
+++ b/test/bigml/test/api/t02.clj
@@ -12,7 +12,7 @@
   "Successfully creating a prediction in DEV mode"
   (api/with-dev-mode true
     (let [test-data ["test/data/iris.csv.gz"
-                     {:prediction [1.44 0.54 2.2]}
+                     {:prediction {:input_data [1.44 0.54 2.2]}}
                      "Iris-setosa"]
           prediction (test/create-get-cleanup
                       [:source :dataset :model :prediction] test-data)]

--- a/test/bigml/test/api/t02.clj
+++ b/test/bigml/test/api/t02.clj
@@ -1,0 +1,19 @@
+;; Copyright 2012, 2016 BigML
+;; Licensed under the Apache License, Version 2.0
+;; http://www.apache.org/licenses/LICENSE-2.0
+
+(ns bigml.test.api.t02
+  "Testing prediction creation in DEV mode"
+  (:require (bigml.api [core :as api])
+            (bigml.test.api [utils :as test]))
+  (:use clojure.test))
+
+(deftest ts01
+  "Successfully creating a prediction in DEV mode"
+  (api/with-dev-mode true
+    (let [test-data ["test/data/iris.csv.gz"
+                     {:prediction [1.44 0.54 2.2]}
+                     "Iris-setosa"]
+          prediction (test/create-get-cleanup
+                      [:source :dataset :model :prediction] test-data)]
+      (is (= (last test-data) (first (vals (:prediction prediction))))))))

--- a/test/bigml/test/api/utils.clj
+++ b/test/bigml/test/api/utils.clj
@@ -41,7 +41,8 @@
   [verb res-type res-uuid & params]
   (apply (get-in api-fns [res-type verb])
          res-uuid
-         (if (nil? params) params [params])))
+         (if (nil? params) params [params])
+         ))
 
 (defn- create-arg-type
   "This is used to select the proper implementation of the create multimethod"
@@ -68,17 +69,17 @@
 (defmethod create :sequence
   [res-type res-uuid & params]
   (reduce
-      #(conj %1 (:resource
-                 (apply create %2 (last %1) (%2 (first params)))))
-      [res-uuid]
-      res-type))
+   #(conj %1 (:resource
+              (apply create %2 (last %1) (%2 (first params)))))
+   [res-uuid]
+   res-type))
 
 (defn create-get-cleanup
   "This function wraps create so it does a GET of the last resource
    returned by create and returns it; additionally, it deletes
    all resources created remotely."
-  [res-type res-uuid & params]
-  (let [resources (apply create res-type res-uuid params)
+  [res-type [res-uuid params]]
+  (let [resources (create res-type res-uuid params)
         result (api/get-final (last resources))]
     (doall (pmap api/delete (drop 1 resources)))
     result))

--- a/test/bigml/test/api/utils.clj
+++ b/test/bigml/test/api/utils.clj
@@ -38,8 +38,7 @@
    in place of the less flexible
      (bigml.api.source/create file-path options)"
   [verb res-type res-uuid params]
-  (let [_ (println "do-verb: " verb "-" params)
-        inputs (:input_data params)
+  (let [inputs (:input_data params)
         params (:options params)]
    (if (nil? inputs)
      (apply (get-in api-fns [res-type verb])

--- a/test/bigml/test/api/utils.clj
+++ b/test/bigml/test/api/utils.clj
@@ -64,8 +64,8 @@
 
 (defn create-get-cleanup
   "This function wraps create so it does a GET of the last resource
-   returned by create and returns it; additionally, it deletes remotely
-   all created resources."
+   returned by create and returns it; additionally, it deletes
+   all resources created remotely."
   [res-type res-uuid & params]
   (let [resources (apply create res-type res-uuid params)
         result (api/get-final (last resources))]

--- a/test/bigml/test/api/utils.clj
+++ b/test/bigml/test/api/utils.clj
@@ -19,8 +19,7 @@
   and BIGML_API_KEY environment variables"
   []
   (let [username (System/getenv "BIGML_USERNAME")
-        api-key (System/getenv "BIGML_API_KEY")
-        _ (println "AUTH:    " username api-key)]
+        api-key (System/getenv "BIGML_API_KEY")]
     (api/make-connection username api-key)))
 
 (def api-fns
@@ -38,11 +37,10 @@
      (create source file-path options)
    in place of the less flexible
      (bigml.api.source/create file-path options)"
-  [verb res-type res-uuid & params]
+  [verb res-type res-uuid params]
   (apply (get-in api-fns [res-type verb])
-         res-uuid
-         (if (nil? params) params [params])
-         ))
+          res-uuid
+          (if (nil? params) params [params])))
 
 (defn- create-arg-type
   "This is used to select the proper implementation of the create multimethod"
@@ -69,10 +67,10 @@
 (defmethod create :sequence
   [res-type res-uuid & params]
   (reduce
-   #(conj %1 (:resource
-              (apply create %2 (last %1) (%2 (first params)))))
-   [res-uuid]
-   res-type))
+    #(conj %1 (:resource
+               (create %2 (last %1) (%2 (first params)))))
+    [res-uuid]
+    res-type))
 
 (defn create-get-cleanup
   "This function wraps create so it does a GET of the last resource

--- a/test/bigml/test/api/utils.clj
+++ b/test/bigml/test/api/utils.clj
@@ -32,15 +32,23 @@
    :prediction {:create prediction/create}})
 
 (defn- do-verb
-  "this function is a sort of universal wrapper around individual create
+  "This function is a sort of universal wrapper around individual create
    functions that reside in specific namespaces. it enables the syntax:
      (create source file-path options)
    in place of the less flexible
      (bigml.api.source/create file-path options)"
   [verb res-type res-uuid params]
-  (apply (get-in api-fns [res-type verb])
-          res-uuid
-          (if (nil? params) params [params])))
+  (let [_ (println "do-verb: " verb "-" params)
+        inputs (:input_data params)
+        params (:options params)]
+   (if (nil? inputs)
+     (apply (get-in api-fns [res-type verb])
+           res-uuid
+           (flatten (seq params)))
+     (apply (get-in api-fns [res-type verb])
+           res-uuid
+           inputs
+           (flatten (seq params))))))
 
 (defn- create-arg-type
   "This is used to select the proper implementation of the create multimethod"


### PR DESCRIPTION
This PR mostly introduces the required changes to make it possible to specify the inputs to a prediction through a map of the following kind, where field names are used instead of field IDs:

```
{:input_data
  {"sépal.length" 0.25
    "pétal&width" 0.5}
  :options
  { :by-field-name true }}
```

This adds to the two previously supported ways to specify inputs to a prediction.

Additionally, a few bugs are fixed preventing from specifying predictions through their field IDs (only positional inputs worked correctly) and some related refactoring.
